### PR TITLE
Ensure repository row status stays synchronized

### DIFF
--- a/assets/admin.js
+++ b/assets/admin.js
@@ -489,6 +489,7 @@ jQuery(document).ready(function($) {
         const $installButton = $actionsCell.find('.kiss-sbi-install-single');
         const $row = $button.closest('tr');
         const $statusCell = $row.find('.kiss-sbi-plugin-status');
+        const $checkbox = $row.find('.kiss-sbi-repo-checkbox');
 
         $button.prop('disabled', true).text('Checking...');
 
@@ -511,6 +512,8 @@ jQuery(document).ready(function($) {
                     // Remove the check button and install button, then show Activate only if inactive
                     $button.remove();
                     $installButton.remove();
+                    $checkbox.prop('checked', false).prop('disabled', true);
+                    $row.addClass('plugin-installed');
                     if (!pluginData.active) {
                         $actionsCell.prepend(
                             '<button type="button" class="button button-primary kiss-sbi-activate-plugin" data-plugin-file="' +
@@ -522,7 +525,11 @@ jQuery(document).ready(function($) {
                     $button.remove();
                     $statusCell.removeClass('is-installed').empty();
                     $installButton.show().prop('disabled', false);
+                    $checkbox.prop('disabled', false);
+                    $row.removeClass('plugin-installed');
                 }
+                updateCheckedPlugins();
+                updateBatchInstallButton();
             },
             error: function() {
                 $button.prop('disabled', false).text('Check Status');

--- a/temp_changelog_entry.md
+++ b/temp_changelog_entry.md
@@ -5,6 +5,7 @@
 - Verbose Upgrader error logs surfaced in UI for single and batch installs; logs available via console
 - Self Tests: added Upgrader dry-run (non-destructive HEAD check for main.zip)
 - Cleaned up legacy manual download/extract helpers; rely on Upgrader and WP_Filesystem
+- Synced repository row controls after install status checks to prevent conflicting states (admin.js)
 
 ### Security/Compatibility
 - Prefer WP_Filesystem operations during Upgrader filters (rename/move/delete) and fallback to direct methods only if necessary


### PR DESCRIPTION
## Summary
- sync row checkbox and styling after installation status checks so each column reflects the same state
- document row consistency fix in changelog

## Testing
- `node --check assets/admin.js`


------
https://chatgpt.com/codex/tasks/task_b_68a69f2e4640832eb3dd1b76683730b4