### PR TITLE
feat: scaffold v2 architecture with feature flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .DS_Store
+node_modules/
+vendor/
+*.log

--- a/includes/bootstrap-v2.php
+++ b/includes/bootstrap-v2.php
@@ -1,0 +1,19 @@
+<?php
+if (!defined('ABSPATH')) exit;
+
+// PSR-4 Autoloader for v2
+spl_autoload_register(function ($class) {
+    if (strpos($class, 'KissSmartBatchInstaller\\V2\\') === 0) {
+        $relative_class = str_replace('KissSmartBatchInstaller\\V2\\', '', $class);
+        $file = KISS_SBI_PLUGIN_DIR . 'src-v2/' . str_replace('\\\\', '/', $relative_class) . '.php';
+
+        if (file_exists($file)) {
+            require $file;
+        }
+    }
+});
+
+// Development constant for easy testing
+if (!defined('KISS_SBI_FORCE_V2')) {
+    define('KISS_SBI_FORCE_V2', WP_DEBUG && isset($_GET['kiss_sbi_v2']));
+}

--- a/src-v2/Admin/AjaxHandler.php
+++ b/src-v2/Admin/AjaxHandler.php
@@ -1,0 +1,19 @@
+<?php
+namespace KissSmartBatchInstaller\V2\Admin;
+
+class AjaxHandler
+{
+    private $pluginService;
+    private $installationService;
+
+    public function __construct($pluginService, $installationService)
+    {
+        $this->pluginService = $pluginService;
+        $this->installationService = $installationService;
+    }
+
+    public function init(): void
+    {
+        // Placeholder for AJAX actions
+    }
+}

--- a/src-v2/Admin/Controllers/PluginsController.php
+++ b/src-v2/Admin/Controllers/PluginsController.php
@@ -1,0 +1,22 @@
+<?php
+namespace KissSmartBatchInstaller\V2\Admin\Controllers;
+
+use KissSmartBatchInstaller\V2\Admin\Views\PluginsListTable;
+
+class PluginsController
+{
+    private $container;
+    private $listTable;
+
+    public function __construct($container)
+    {
+        $this->container = $container;
+        $this->listTable = $container->get('PluginsListTable');
+    }
+
+    public function render(): void
+    {
+        $listTable = $this->listTable;
+        include KISS_SBI_PLUGIN_DIR . 'views/admin/plugins-list.php';
+    }
+}

--- a/src-v2/Admin/Controllers/SettingsController.php
+++ b/src-v2/Admin/Controllers/SettingsController.php
@@ -1,0 +1,10 @@
+<?php
+namespace KissSmartBatchInstaller\V2\Admin\Controllers;
+
+class SettingsController
+{
+    public function __construct($container)
+    {
+        // Placeholder for future settings controller
+    }
+}

--- a/src-v2/Admin/Views/PluginsListTable.php
+++ b/src-v2/Admin/Views/PluginsListTable.php
@@ -1,0 +1,100 @@
+<?php
+namespace KissSmartBatchInstaller\V2\Admin\Views;
+
+if (!class_exists('WP_List_Table')) {
+    require_once ABSPATH . 'wp-admin/includes/class-wp-list-table.php';
+}
+
+class PluginsListTable extends \WP_List_Table
+{
+    private $pluginService;
+
+    public function __construct($pluginService)
+    {
+        parent::__construct([
+            'singular' => 'repository',
+            'plural'   => 'repositories',
+            'ajax'     => true,
+        ]);
+        $this->pluginService = $pluginService;
+    }
+
+    public function get_columns(): array
+    {
+        return [
+            'cb'         => '<input type="checkbox" />',
+            'plugin'     => __('Plugin', 'kiss-smart-batch-installer'),
+            'description'=> __('Description', 'kiss-smart-batch-installer'),
+            'actions'    => __('Actions', 'kiss-smart-batch-installer'),
+        ];
+    }
+
+    public function column_cb($item): string
+    {
+        $plugin   = $this->pluginService->getPlugin($item['name']);
+        $disabled = $plugin->isInstalled() ? 'disabled' : '';
+        return sprintf('<input type="checkbox" name="repositories[]" value="%s" %s />', esc_attr($item['name']), $disabled);
+    }
+
+    public function column_plugin($item): string
+    {
+        $plugin = $this->pluginService->getPlugin($item['name']);
+        $title  = sprintf('<strong><a href="%s" target="_blank">%s</a></strong>', esc_url($item['url']), esc_html($item['name']));
+        $state_label = $plugin->getStateLabel();
+        if ($state_label) {
+            $title .= ' — <span class="plugin-state">' . esc_html($state_label) . '</span>';
+        }
+        return $title;
+    }
+
+    public function column_description($item): string
+    {
+        $plugin = $this->pluginService->getPlugin($item['name']);
+        $html   = esc_html($item['description']);
+        $meta   = [];
+        if ($plugin->getVersion()) {
+            $meta[] = sprintf(__('Version %s', 'kiss-smart-batch-installer'), esc_html($plugin->getVersion()));
+        }
+        if (!empty($item['language'])) {
+            $meta[] = esc_html($item['language']);
+        }
+        if (!empty($item['updated_at'])) {
+            $meta[] = sprintf(__('Updated %s ago', 'kiss-smart-batch-installer'), human_time_diff(strtotime($item['updated_at'])));
+        }
+        if (!empty($meta)) {
+            $html .= '<br><em>' . implode(' | ', $meta) . '</em>';
+        }
+        return $html;
+    }
+
+    public function column_actions($item): string
+    {
+        $plugin  = $this->pluginService->getPlugin($item['name']);
+        $buttons = $plugin->getActionButtons();
+        $html    = [];
+        foreach ($buttons as $button) {
+            if (isset($button['condition']) && !$button['condition']) {
+                continue;
+            }
+            $classes = ['button'];
+            if ($button['primary'] ?? false) {
+                $classes[] = 'button-primary';
+            }
+            if ($button['secondary'] ?? false) {
+                $classes[] = 'button-secondary';
+            }
+            if (isset($button['url'])) {
+                $html[] = sprintf('<a href="%s" class="%s">%s</a>', esc_url($button['url']), implode(' ', $classes), esc_html($button['text']));
+            } else {
+                $html[] = sprintf('<button type="button" class="%s" data-action="%s" data-repo="%s">%s</button>', implode(' ', $classes), esc_attr($button['type']), esc_attr($item['name']), esc_html($button['text']));
+            }
+        }
+        return implode(' ', $html);
+    }
+
+    public function prepare_items(): void
+    {
+        $this->items = []; // Placeholder
+        $this->_column_headers = [$this->get_columns(), [], []];
+    }
+}

--- a/src-v2/Assets/PluginManager.js
+++ b/src-v2/Assets/PluginManager.js
@@ -1,0 +1,9 @@
+class PluginManagerV2 {
+    constructor() {
+        // Placeholder implementation
+    }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    new PluginManagerV2();
+});

--- a/src-v2/Assets/admin-v2.css
+++ b/src-v2/Assets/admin-v2.css
@@ -1,0 +1,1 @@
+/* Placeholder styles for v2 admin interface */

--- a/src-v2/Container.php
+++ b/src-v2/Container.php
@@ -1,0 +1,51 @@
+<?php
+namespace KissSmartBatchInstaller\V2;
+
+use KissSmartBatchInstaller\V2\Admin\Controllers\PluginsController;
+use KissSmartBatchInstaller\V2\Admin\Controllers\SettingsController;
+use KissSmartBatchInstaller\V2\Admin\Views\PluginsListTable;
+use KissSmartBatchInstaller\V2\Admin\AjaxHandler;
+use KissSmartBatchInstaller\V2\Core\Services\PluginService;
+use KissSmartBatchInstaller\V2\Core\Services\GitHubService;
+use KissSmartBatchInstaller\V2\Core\Services\InstallationService;
+use KissSmartBatchInstaller\V2\Core\Services\CacheService;
+use KissSmartBatchInstaller\V2\Core\Integration\PQSIntegration;
+
+class Container
+{
+    private $instances = [];
+
+    public function get(string $id)
+    {
+        if (!isset($this->instances[$id])) {
+            $this->instances[$id] = $this->create($id);
+        }
+        return $this->instances[$id];
+    }
+
+    private function create(string $id)
+    {
+        switch ($id) {
+            case 'PluginsController':
+                return new PluginsController($this);
+            case 'SettingsController':
+                return new SettingsController($this);
+            case 'PluginsListTable':
+                return new PluginsListTable($this->get('PluginService'));
+            case 'AjaxHandler':
+                return new AjaxHandler($this->get('PluginService'), $this->get('InstallationService'));
+            case 'PluginService':
+                return new PluginService();
+            case 'GitHubService':
+                return new GitHubService();
+            case 'InstallationService':
+                return new InstallationService();
+            case 'CacheService':
+                return new CacheService();
+            case 'PQSIntegration':
+                return new PQSIntegration();
+            default:
+                throw new \InvalidArgumentException('Unknown service: ' . $id);
+        }
+    }
+}

--- a/src-v2/Core/Integration/PQSIntegration.php
+++ b/src-v2/Core/Integration/PQSIntegration.php
@@ -1,0 +1,10 @@
+<?php
+namespace KissSmartBatchInstaller\V2\Core\Integration;
+
+class PQSIntegration
+{
+    public function getPluginData(string $repositoryName)
+    {
+        return null; // Placeholder
+    }
+}

--- a/src-v2/Core/Models/InstallationResult.php
+++ b/src-v2/Core/Models/InstallationResult.php
@@ -1,0 +1,11 @@
+<?php
+namespace KissSmartBatchInstaller\V2\Core\Models;
+
+class InstallationResult
+{
+    public bool $success = false;
+    public string $plugin_dir = '';
+    public string $plugin_file = '';
+    public bool $activated = false;
+    public array $logs = [];
+}

--- a/src-v2/Core/Models/Plugin.php
+++ b/src-v2/Core/Models/Plugin.php
@@ -1,0 +1,94 @@
+<?php
+namespace KissSmartBatchInstaller\V2\Core\Models;
+
+class Plugin
+{
+    public const STATE_UNKNOWN = 'unknown';
+    public const STATE_CHECKING = 'checking';
+    public const STATE_AVAILABLE = 'available';
+    public const STATE_INSTALLED_INACTIVE = 'installed_inactive';
+    public const STATE_INSTALLED_ACTIVE = 'installed_active';
+    public const STATE_NOT_PLUGIN = 'not_plugin';
+    public const STATE_ERROR = 'error';
+
+    private string $repositoryName;
+    private string $state = self::STATE_UNKNOWN;
+    private ?string $pluginFile = null;
+    private ?string $settingsUrl = null;
+    private ?string $errorMessage = null;
+    private array $metadata = [];
+
+    public function __construct(string $repositoryName)
+    {
+        $this->repositoryName = $repositoryName;
+    }
+
+    public function isInstallable(): bool
+    {
+        return $this->state === self::STATE_AVAILABLE;
+    }
+
+    public function isInstalled(): bool
+    {
+        return in_array($this->state, [self::STATE_INSTALLED_INACTIVE, self::STATE_INSTALLED_ACTIVE], true);
+    }
+
+    public function isActive(): bool
+    {
+        return $this->state === self::STATE_INSTALLED_ACTIVE;
+    }
+
+    public function getStateLabel(): string
+    {
+        return match($this->state) {
+            self::STATE_INSTALLED_ACTIVE => __('Active', 'kiss-smart-batch-installer'),
+            self::STATE_INSTALLED_INACTIVE => __('Inactive', 'kiss-smart-batch-installer'),
+            self::STATE_NOT_PLUGIN => __('Not a WordPress Plugin', 'kiss-smart-batch-installer'),
+            self::STATE_ERROR => __('Error', 'kiss-smart-batch-installer'),
+            self::STATE_CHECKING => __('Checking...', 'kiss-smart-batch-installer'),
+            default => ''
+        };
+    }
+
+    public function getActionButtons(): array
+    {
+        return match($this->state) {
+            self::STATE_AVAILABLE => [
+                ['type' => 'install', 'text' => __('Install', 'kiss-smart-batch-installer'), 'primary' => true],
+            ],
+            self::STATE_INSTALLED_INACTIVE => [
+                ['type' => 'activate', 'text' => __('Activate', 'kiss-smart-batch-installer'), 'primary' => true],
+                ['type' => 'settings', 'text' => __('Settings', 'kiss-smart-batch-installer'), 'url' => $this->settingsUrl, 'condition' => !empty($this->settingsUrl)]
+            ],
+            self::STATE_INSTALLED_ACTIVE => [
+                ['type' => 'deactivate', 'text' => __('Deactivate', 'kiss-smart-batch-installer')],
+                ['type' => 'settings', 'text' => __('Settings', 'kiss-smart-batch-installer'), 'url' => $this->settingsUrl, 'condition' => !empty($this->settingsUrl)]
+            ],
+            self::STATE_NOT_PLUGIN => [],
+            self::STATE_ERROR => [
+                ['type' => 'retry', 'text' => __('Retry', 'kiss-smart-batch-installer'), 'secondary' => true]
+            ],
+            self::STATE_CHECKING => [],
+            default => [
+                ['type' => 'check', 'text' => __('Check Status', 'kiss-smart-batch-installer'), 'primary' => true]
+            ]
+        };
+    }
+
+    public function setState(string $state, ?string $errorMessage = null): void
+    {
+        $this->state = $state;
+        $this->errorMessage = $errorMessage;
+    }
+
+    public function getState(): string { return $this->state; }
+    public function getRepositoryName(): string { return $this->repositoryName; }
+    public function getPluginFile(): ?string { return $this->pluginFile; }
+    public function setPluginFile(?string $pluginFile): void { $this->pluginFile = $pluginFile; }
+    public function getSettingsUrl(): ?string { return $this->settingsUrl; }
+    public function setSettingsUrl(?string $settingsUrl): void { $this->settingsUrl = $settingsUrl; }
+    public function getMetadata(): array { return $this->metadata; }
+    public function setMetadata(array $metadata): void { $this->metadata = $metadata; }
+    public function getVersion(): ?string { return $this->metadata['version'] ?? null; }
+    public function getDescription(): ?string { return $this->metadata['description'] ?? null; }
+}

--- a/src-v2/Core/Models/Repository.php
+++ b/src-v2/Core/Models/Repository.php
@@ -1,0 +1,17 @@
+<?php
+namespace KissSmartBatchInstaller\V2\Core\Models;
+
+class Repository
+{
+    public string $name;
+    public string $url;
+    public string $description = '';
+    public string $language = '';
+    public ?string $updated_at = null;
+
+    public function __construct(string $name, string $url)
+    {
+        $this->name = $name;
+        $this->url = $url;
+    }
+}

--- a/src-v2/Core/Services/CacheService.php
+++ b/src-v2/Core/Services/CacheService.php
@@ -1,0 +1,15 @@
+<?php
+namespace KissSmartBatchInstaller\V2\Core\Services;
+
+class CacheService
+{
+    public function get(string $key)
+    {
+        return get_transient($key);
+    }
+
+    public function set(string $key, $value, int $expiration = 0): void
+    {
+        set_transient($key, $value, $expiration);
+    }
+}

--- a/src-v2/Core/Services/GitHubService.php
+++ b/src-v2/Core/Services/GitHubService.php
@@ -1,0 +1,10 @@
+<?php
+namespace KissSmartBatchInstaller\V2\Core\Services;
+
+class GitHubService
+{
+    public function isWordPressPlugin(string $repositoryName)
+    {
+        return false; // Placeholder
+    }
+}

--- a/src-v2/Core/Services/InstallationService.php
+++ b/src-v2/Core/Services/InstallationService.php
@@ -1,0 +1,10 @@
+<?php
+namespace KissSmartBatchInstaller\V2\Core\Services;
+
+class InstallationService
+{
+    public function isInstalled(string $repositoryName)
+    {
+        return false; // Placeholder
+    }
+}

--- a/src-v2/Core/Services/PluginService.php
+++ b/src-v2/Core/Services/PluginService.php
@@ -1,0 +1,12 @@
+<?php
+namespace KissSmartBatchInstaller\V2\Core\Services;
+
+use KissSmartBatchInstaller\V2\Core\Models\Plugin;
+
+class PluginService
+{
+    public function getPlugin(string $repositoryName): Plugin
+    {
+        return new Plugin($repositoryName);
+    }
+}

--- a/src-v2/Plugin.php
+++ b/src-v2/Plugin.php
@@ -1,0 +1,65 @@
+<?php
+namespace KissSmartBatchInstaller\V2;
+
+class Plugin
+{
+    private $container;
+
+    public function __construct()
+    {
+        $this->container = new Container();
+    }
+
+    public function init(): void
+    {
+        add_action('admin_menu', [$this, 'addAdminPages']);
+        add_action('admin_enqueue_scripts', [$this, 'enqueueAssets']);
+
+        // Initialize AJAX handlers
+        $this->container->get('AjaxHandler')->init();
+    }
+
+    public function addAdminPages(): void
+    {
+        add_plugins_page(
+            __('GitHub Repositories (v2)', 'kiss-smart-batch-installer'),
+            __('GitHub Repos (v2)', 'kiss-smart-batch-installer'),
+            'install_plugins',
+            'kiss-smart-batch-installer-v2',
+            [$this, 'renderPluginsPage']
+        );
+    }
+
+    public function renderPluginsPage(): void
+    {
+        $controller = $this->container->get('PluginsController');
+        $controller->render();
+    }
+
+    public function enqueueAssets($hook): void
+    {
+        if (strpos($hook, 'kiss-smart-batch-installer-v2') === false) {
+            return;
+        }
+
+        wp_enqueue_script(
+            'kiss-sbi-v2-admin',
+            KISS_SBI_PLUGIN_URL . 'src-v2/Assets/PluginManager.js',
+            ['jquery'],
+            KISS_SBI_VERSION,
+            true
+        );
+
+        wp_enqueue_style(
+            'kiss-sbi-v2-admin',
+            KISS_SBI_PLUGIN_URL . 'src-v2/Assets/admin-v2.css',
+            [],
+            KISS_SBI_VERSION
+        );
+
+        wp_localize_script('kiss-sbi-v2-admin', 'kissSbiV2Ajax', [
+            'ajaxUrl' => admin_url('admin-ajax.php'),
+            'nonce' => wp_create_nonce('kiss_sbi_v2_nonce'),
+        ]);
+    }
+}

--- a/src/Admin/AdminInterface.php
+++ b/src/Admin/AdminInterface.php
@@ -72,6 +72,10 @@ class AdminInterface
             'sanitize_callback' => 'absint'
         ]);
 
+        register_setting('kiss_sbi_settings', 'kiss_sbi_use_v2', [
+            'sanitize_callback' => 'absint'
+        ]);
+
         add_settings_section(
             'kiss_sbi_main_settings',
             __('GitHub Organization Settings', 'kiss-smart-batch-installer'),
@@ -99,6 +103,14 @@ class AdminInterface
             'kiss_sbi_cache_duration',
             __('Cache Duration (seconds)', 'kiss-smart-batch-installer'),
             [$this, 'cacheDurationFieldCallback'],
+            'kiss_sbi_settings',
+            'kiss_sbi_main_settings'
+        );
+
+        add_settings_field(
+            'kiss_sbi_use_v2',
+            __('Use New Interface (Beta)', 'kiss-smart-batch-installer'),
+            [$this, 'useV2FieldCallback'],
             'kiss_sbi_settings',
             'kiss_sbi_main_settings'
         );
@@ -886,5 +898,13 @@ class AdminInterface
         $value = get_option('kiss_sbi_cache_duration', 3600);
         echo '<input type="number" name="kiss_sbi_cache_duration" value="' . esc_attr($value) . '" min="300" class="regular-text">';
         echo '<p class="description">' . __('How long to cache repository data (in seconds). Default: 3600 (1 hour).', 'kiss-smart-batch-installer') . '</p>';
+    }
+
+    public function useV2FieldCallback()
+    {
+        $value = get_option('kiss_sbi_use_v2', false);
+        echo '<input type="checkbox" name="kiss_sbi_use_v2" value="1" ' . checked($value, true, false) . '>';
+        echo '<p class="description">' . __('Enable the new WordPress-native interface.', 'kiss-smart-batch-installer') . ' ';
+        echo '<a href="admin.php?page=kiss-smart-batch-installer&kiss_sbi_v2=1" target="_blank">' . __('Preview', 'kiss-smart-batch-installer') . '</a></p>';
     }
 }

--- a/views/admin/plugins-list.php
+++ b/views/admin/plugins-list.php
@@ -1,0 +1,13 @@
+<?php
+use KissSmartBatchInstaller\V2\Admin\Views\PluginsListTable;
+/** @var PluginsListTable $listTable */
+?>
+<div class="wrap">
+    <h1><?php echo esc_html__('GitHub Repositories', 'kiss-smart-batch-installer'); ?></h1>
+    <form method="post">
+        <?php
+        $listTable->prepare_items();
+        $listTable->display();
+        ?>
+    </form>
+</div>


### PR DESCRIPTION
## Summary
- add feature flag and bootstrap for parallel v2 plugin architecture
- scaffold v2 plugin, container, models, and WP_List_Table view
- expose beta toggle in settings and basic assets

## Testing
- `php -l KISS-smart-batch-installer.php`
- `php -l src-v2/Container.php`
- `php -l src-v2/Admin/Controllers/PluginsController.php`
- `php -l src-v2/Admin/Controllers/SettingsController.php`
- `php -l src-v2/Admin/AjaxHandler.php`
- `php -l src-v2/Admin/Views/PluginsListTable.php`
- `php -l src-v2/Core/Models/Plugin.php`
- `php -l src-v2/Core/Models/Repository.php`
- `php -l src-v2/Core/Models/InstallationResult.php`
- `php -l src-v2/Core/Services/PluginService.php`
- `php -l src-v2/Core/Services/GitHubService.php`
- `php -l src-v2/Core/Services/InstallationService.php`
- `php -l src-v2/Core/Services/CacheService.php`
- `php -l src-v2/Core/Integration/PQSIntegration.php`
- `php -l views/admin/plugins-list.php`
- `node -c src-v2/Assets/PluginManager.js && echo "Syntax OK"`


------
https://chatgpt.com/codex/tasks/task_b_68a73dc3e048832eb8ccb16fa09793e0